### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.10"
+
+install:
+    - sudo aptitude -y install xvfb
+    - git submodule update --init
+    - xvfb-run cpanm --installdeps . || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - RELEASE_TESTING=1 AUTHOR_TESTING=1 xvfb-run make test


### PR DESCRIPTION
Note that Perl 5.12 can't be tested since the installation of the
`Alien::Electron` dependency on this version hangs.

Hi there :-)  I got another dist of yours for this month's PRC, hope you don't mind!

It seems there's an issue with `Alien::Electron` with Perl 5.12 that you might want to look into.  After downloading the electron package, the process hangs and keeps burning CPU but does nothing.  Anyway, thought you'd like to know about that.

BTW: I'm still mulling over the issue with the test failures in `String::Compare::ConstantTime` wrt utf8 etc. and have a couple of extra tests in the works, so will submit another pull request as soon as I get things more polished.