### PR TITLE
Add README to MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ lib/Valence.pm
 lib/Valence/Object.pm
 Makefile.PL
 MANIFEST
+README
 t/ipc.t
 t/load.t
 t/static/remote.html


### PR DESCRIPTION
[CPANTS](https://cpants.cpanauthors.org/dist/Valence) noticed that the
README was missing: the file is included in the dist but not in the
MANIFEST.  This patch brings the MANIFEST up to date.