### PR TITLE
Explicitly set minimum Perl version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 use strict;
 
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker qw(6.48);
 use File::ShareDir::Install;
 
 
@@ -37,6 +37,7 @@ my %args = (
         bugtracker => 'https://github.com/hoytech/Valence-p5/issues',
       },
     },
+    MIN_PERL_VERSION => 5.6.0,
 );
 
 WriteMakefile(%args);


### PR DESCRIPTION
Perl::MinimumVersion showed that the minimum (syntax) version of Perl
compatible with this dist is 5.6.0, hence this change.

This change should fix the meta_yml_declares_perl_version issue noticed on [CPANTS](https://cpants.cpanauthors.org/dist/Valence).