### PR TITLE
Makefile.PL metadata cleanups

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ install_share dist => 'valence/app';
 
 my %args = (
     NAME => 'Valence',
+    AUTHOR => ['Doug Hoyte <doug@hcsw.org>'],
     VERSION_FROM => 'lib/Valence.pm',
     PREREQ_PM => {
       'Alien::Electron' => '0.102',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ my %args = (
     NAME => 'Valence',
     AUTHOR => ['Doug Hoyte <doug@hcsw.org>'],
     VERSION_FROM => 'lib/Valence.pm',
+    ABSTRACT_FROM => 'lib/Valence.pm',
     PREREQ_PM => {
       'Alien::Electron' => '0.102',
       'common::sense' => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,8 +27,6 @@ my %args = (
     CONFIGURE_REQUIRES => {
       'File::ShareDir::Install' => 0,
     },
-    LIBS => [],
-    DEFINE => '',
     LICENSE => 'perl',
     dist => {
       PREOP => 'pod2text $(VERSION_FROM) > $(DISTVNAME)/README',


### PR DESCRIPTION
The author and abstract information was missing from the Makefile.PL metadata; also, a couple of variables didn't need to be defined, hence they could be deleted.